### PR TITLE
[NOSTORY] Make username comparison case-insensitive

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/UserModelFactory.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/UserModelFactory.java
@@ -97,7 +97,10 @@ public class UserModelFactory {
     }
 
     private void validateUsernamesEqual(LegacyUser legacyUser, UserModel userModel) {
-        if (!userModel.getUsername().equals(legacyUser.getUsername())) {
+        // Keycloak stores the username as all lowercase, but the response from ud-api might include capitalization
+        // because we store them in `updox.user_info` retaining the capitalization (even though Catalyst logins
+        // are case-insensitive)
+        if (!userModel.getUsername().equalsIgnoreCase(legacyUser.getUsername())) {
             throw new IllegalStateException(String.format("Local and remote users differ: [%s != %s]",
                     userModel.getUsername(),
                     legacyUser.getUsername()));

--- a/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
+++ b/src/test/java/com/danielfrak/code/keycloak/providers/rest/LegacyProviderTest.java
@@ -192,7 +192,7 @@ class LegacyProviderTest {
                 .thenReturn(password);
         when(legacyUserService.isPasswordValid(userId, password))
                 .thenReturn(true);
-        
+
         // JUnit was complaining about this "unnecessary" stub
         //        when(session.userCredentialManager())
         //                .thenReturn(mock(UserCredentialManager.class));


### PR DESCRIPTION
Make username comparison case-insensitive to prevent cases where we are trying to login as "user@updox.com" but the Catalyst database has the username as "user@Updox.com" (which would be a valid login attempt) and this extension fails the user lookup.