### PR TITLE
[KEYCL-234] Ensure client resources are closed

### DIFF
--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/LegacyProvider.java
@@ -58,7 +58,7 @@ public class LegacyProvider implements UserStorageProvider,
             //      created because it already exists
             // So if the session context client is null (which would only happen on API calls), skip this plugin entirely
             // to ensure the API can do what it needs to do without someone stepping on its toes
-            LOG.error("Skipping legacy user lookup, client was not present in session context");
+            LOG.debug("Skipping legacy user lookup, client was not present in session context");
             return null;
         }
 
@@ -128,7 +128,7 @@ public class LegacyProvider implements UserStorageProvider,
 
     @Override
     public void close() {
-        // Not needed
+        legacyUserService.close();
     }
 
     @Override

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/remote/LegacyUserService.java
@@ -31,4 +31,6 @@ public interface LegacyUserService {
      * @return true if password is valid.
      */
     boolean isPasswordValid(String username, String password);
+
+    void close();
 }

--- a/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
+++ b/src/main/java/com/danielfrak/code/keycloak/providers/rest/rest/RestUserService.java
@@ -15,9 +15,11 @@ import static com.danielfrak.code.keycloak.providers.rest.ConfigurationPropertie
 public class RestUserService implements LegacyUserService {
 
     private final RestUserClient client;
+    private final Client restEasyClient;
 
     public RestUserService(ComponentModel model, Client restEasyClient) {
         String uri = model.getConfig().getFirst(URI_PROPERTY);
+        this.restEasyClient = restEasyClient;
         var tokenAuthEnabled = Boolean.parseBoolean(model.getConfig().getFirst(API_TOKEN_ENABLED_PROPERTY));
         if (tokenAuthEnabled) {
             String token = model.getConfig().getFirst(API_TOKEN_PROPERTY);
@@ -73,5 +75,10 @@ public class RestUserService implements LegacyUserService {
     public boolean isPasswordValid(String username, String password) {
         final Response response = client.validatePassword(username, new UserPasswordDto(password));
         return response.getStatus() == 200;
+    }
+
+    @Override
+    public void close() {
+        restEasyClient.close();
     }
 }


### PR DESCRIPTION
<!-- Markdown help? See https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet -->
[KEYCL-234](https://myupdox.atlassian.net/browse/KEYCL-234)

<!-- Pull Request Recommendations https://myupdox.atlassian.net/wiki/spaces/EN/pages/85164043/Pull+Requests+PRs -->

### Details
We've been seeing some logs in TEST Keycloak like the following:
```
2022-05-25 14:04:18,878 WARN  [org.jboss.resteasy.client.jaxrs.i18n] (Finalizer) RESTEASY004687: Closing a class org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine instance for you. Please close clients yourself.
```

This PR ensures that these clients are closed when the plugin processing finishes

### Tasks

- [x] Completed all _Acceptance Criteria_
- [x] Developer testing
- [ ] Test plan