### PR TITLE
[KEYCL-518] bypass password complexity check when importing users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>keycloak-server-spi</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jboss.logging/jboss-logging -->
         <dependency>

--- a/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,7 @@
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
+    <deployment>
+        <dependencies>
+            <module name="org.keycloak.keycloak-services" />
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>


### PR DESCRIPTION
<!-- Base Template used through `updox` org in github -->

<!-- Markdown help? See https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet -->
[KEYCL-518](https://myupdox.atlassian.net/browse/KEYCL-518)

<!-- Pull Request Recommendations https://myupdox.atlassian.net/wiki/spaces/EN/pages/85164043/Pull+Requests+PRs -->

### Details

- When importing a user into Keycloak's internal user database from Catalyst, we want to bypass checking the password against Keycloak's complexity/history rules. This will allow us to perform a seamless migration and not have to force users to reset their passwords until we're ready with the password expiration functionality.

### Tasks

- [x] JIRA ticket is identified in commit(s) - **DO NOT MERGE WITHOUT THIS** ([_Additional Info_](https://myupdox.atlassian.net/wiki/spaces/EN/pages/85164043/Pull+Requests+PRs#General-Guidelines))
- [ ] Completed all _Acceptance Criteria_ of the aforementioned ticket
- [x] Developer testing
- [ ] Unit tests
- [x] Test plan

[KEYCL-518]: https://myupdox.atlassian.net/browse/KEYCL-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ